### PR TITLE
feat: integrate A8 vectorizer service

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,6 +20,7 @@ DEWATERMARK_API_KEY=your_dewatermark_api_key
 # Vectorizer.ai API配置
 VECTORIZER_API_KEY=your_vectorizer_api_key
 VECTORIZER_API_SECRET=your_vectorizer_api_secret
+A8_VECTORIZER_BASE_URL=https://a8.zifeiyuai.top:2345
 
 # 即梦API配置
 JIMENG_API_KEY=your_jimeng_api_key

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -43,6 +43,7 @@ class Settings(BaseSettings):
     # Vectorizer.ai API配置
     vectorizer_api_key: str = ""
     vectorizer_api_secret: str = ""
+    a8_vectorizer_base_url: str = "https://a8.zifeiyuai.top:2345"
     
     # 即梦API配置
     jimeng_api_key: str = ""

--- a/backend/app/services/ai_client/a8_vectorizer_client.py
+++ b/backend/app/services/ai_client/a8_vectorizer_client.py
@@ -1,0 +1,97 @@
+import asyncio
+import logging
+import time
+from typing import Optional
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class A8VectorizerClient:
+    """A8矢量化服务客户端"""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        default_timeout: int = 120,
+        default_poll_interval: int = 2,
+    ) -> None:
+        self.base_url = (base_url or settings.a8_vectorizer_base_url).rstrip("/")
+        self.default_timeout = default_timeout
+        self.default_poll_interval = default_poll_interval
+
+    async def convert_to_eps(
+        self,
+        image_bytes: bytes,
+        filename: str = "image.png",
+        timeout: Optional[int] = None,
+        poll_interval: Optional[int] = None,
+    ) -> bytes:
+        """上传图片并下载转换后的EPS文件内容"""
+        timeout = timeout or self.default_timeout
+        poll_interval = poll_interval or self.default_poll_interval
+
+        if not self.base_url:
+            raise Exception("服务异常，联系管理员")
+
+        try:
+            async with httpx.AsyncClient(verify=False, timeout=timeout) as client:
+                files = {"file": (filename, image_bytes)}
+                upload_resp = await client.post(f"{self.base_url}/add_task", files=files)
+                upload_resp.raise_for_status()
+                upload_data = upload_resp.json()
+
+                if upload_data.get("code") != 0:
+                    logger.error("A8 vectorizer upload failed: %s", upload_data)
+                    raise Exception("服务异常，联系管理员")
+
+                task_id = upload_data.get("id") or upload_data.get("taskid")
+                if not task_id:
+                    logger.error("A8 vectorizer response missing task id: %s", upload_data)
+                    raise Exception("服务异常，联系管理员")
+
+                start_time = time.monotonic()
+
+                while True:
+                    status_resp = await client.get(
+                        f"{self.base_url}/try_get", params={"taskid": task_id}
+                    )
+                    status_resp.raise_for_status()
+                    status_data = status_resp.json()
+
+                    code = status_data.get("code")
+                    if code == 0:
+                        break
+                    if code == -1:
+                        logger.error(
+                            "A8 vectorizer reported failure for task %s: %s",
+                            task_id,
+                            status_data,
+                        )
+                        raise Exception("服务异常，联系管理员")
+
+                    if time.monotonic() - start_time > timeout:
+                        logger.error(
+                            "A8 vectorizer polling timed out for task %s after %s seconds",
+                            task_id,
+                            timeout,
+                        )
+                        raise Exception("服务异常，联系管理员")
+
+                    await asyncio.sleep(poll_interval)
+
+                download_resp = await client.get(
+                    f"{self.base_url}/get_image", params={"taskid": task_id}
+                )
+                download_resp.raise_for_status()
+                return download_resp.content
+
+        except httpx.HTTPError as exc:
+            logger.error("HTTP request to A8 vectorizer failed: %s", str(exc))
+            raise Exception("服务异常，联系管理员") from exc
+
+        except Exception:
+            raise

--- a/backend/app/services/ai_client/ai_client.py
+++ b/backend/app/services/ai_client/ai_client.py
@@ -310,7 +310,7 @@ class AIClient:
         image_bytes: bytes,
         options: Optional[Dict[str, Any]] = None,
     ) -> str:
-        """AI矢量化(转SVG) - 使用Vectorizer.ai API"""
+        """AI矢量化(转EPS) - 使用A8矢量化服务"""
         return await self.vectorizer_client.vectorize_image(image_bytes, options)
 
     # 去水印相关方法

--- a/backend/app/services/ai_client/vectorizer_client.py
+++ b/backend/app/services/ai_client/vectorizer_client.py
@@ -1,98 +1,58 @@
 import logging
 import os
 import uuid
-from io import BytesIO
 from typing import Any, Dict, Optional
 
-import httpx
-
 from app.core.config import settings
+from app.services.ai_client.a8_vectorizer_client import A8VectorizerClient
 
 logger = logging.getLogger(__name__)
 
 
 class VectorizerClient:
-    """Vectorizer.ai API客户端"""
-    
-    def __init__(self):
-        self.vectorizer_api_key = settings.vectorizer_api_key
-        self.vectorizer_api_secret = settings.vectorizer_api_secret
-        self.vectorizer_url = "https://vectorizer.ai/api/v1/vectorize"
-    
+    """矢量化服务客户端"""
+
+    def __init__(self) -> None:
+        self.a8_client = A8VectorizerClient()
+
     async def vectorize_image(
         self,
         image_bytes: bytes,
         options: Optional[Dict[str, Any]] = None,
     ) -> str:
-        """AI矢量化(转SVG) - 使用Vectorizer.ai API"""
+        """AI矢量化(转EPS) - 使用A8矢量化服务"""
         try:
-            # 准备文件数据
-            files = {
-                'image': ('image.jpeg', BytesIO(image_bytes))
-            }
-            
-            # 准备认证信息
-            auth = (self.vectorizer_api_key, self.vectorizer_api_secret)
-            
-            # 准备请求数据
-            data = {}
-            
-            # 如果提供了额外选项，添加到请求中
-            if options:
-                # Vectorizer.ai支持的各种选项
-                if 'mode' in options:
-                    data['mode'] = options['mode']
-                if 'colors' in options:
-                    data['colors'] = options['colors']
-                if 'filter_speckle' in options:
-                    data['filter_speckle'] = options['filter_speckle']
-                if 'corners_threshold' in options:
-                    data['corners_threshold'] = options['corners_threshold']
-                if 'iterations' in options:
-                    data['iterations'] = options['iterations']
-                if 'layering' in options:
-                    data['layering'] = options['layering']
-                if 'pathsimplify' in options:
-                    data['pathsimplify'] = options['pathsimplify']
-            
-            logger.info("Sending request to Vectorizer.ai API")
-            
-            # 发送请求
-            async with httpx.AsyncClient(timeout=300.0) as client:
-                response = await client.post(
-                    self.vectorizer_url,
-                    files=files,
-                    data=data,
-                    auth=auth
+            options = options or {}
+
+            filename = f"vectorized_{uuid.uuid4().hex[:8]}.eps"
+            file_path = os.path.join(settings.upload_path, "results", filename)
+
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+            source_filename = options.get("filename", "image.png")
+
+            eps_content = await self.a8_client.convert_to_eps(
+                image_bytes,
+                filename=source_filename,
+                timeout=options.get("timeout"),
+                poll_interval=options.get("poll_interval"),
+            )
+
+            with open(file_path, "wb") as output_file:
+                output_file.write(eps_content)
+
+            if os.path.exists(file_path):
+                file_size = os.path.getsize(file_path)
+                logger.info(
+                    "EPS file saved successfully: %s, size: %s bytes",
+                    file_path,
+                    file_size,
                 )
-                response.raise_for_status()
-                
-                # 保存结果为SVG文件
-                filename = f"vectorized_{uuid.uuid4().hex[:8]}.svg"
-                file_path = f"{settings.upload_path}/results/{filename}"
-                
-                # 确保目录存在
-                os.makedirs(os.path.dirname(file_path), exist_ok=True)
-                
-                # 保存文件
-                with open(file_path, "wb") as f:
-                    f.write(response.content)
-                
-                # 验证文件是否保存成功
-                if os.path.exists(file_path):
-                    file_size = os.path.getsize(file_path)
-                    logger.info(f"SVG file saved successfully: {file_path}, size: {file_size} bytes")
-                    
-                    # 读取文件内容的前100个字符进行验证
-                    with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
-                        content_preview = f.read(100)
-                        logger.info(f"SVG file content preview: {content_preview}")
-                else:
-                    logger.error(f"Failed to save SVG file: {file_path}")
-                
-                # 返回文件URL格式，让处理服务可以访问
-                return f"/files/results/{filename}"
-            
+            else:
+                logger.error("Failed to save EPS file: %s", file_path)
+
+            return f"/files/results/{filename}"
+
         except Exception as e:
-            logger.error(f"Vectorize image failed: {str(e)}")
+            logger.error("Vectorize image failed: %s", str(e))
             raise Exception(f"矢量化失败: {str(e)}")

--- a/backend/tests/integration/test_vectorizer.py
+++ b/backend/tests/integration/test_vectorizer.py
@@ -27,7 +27,7 @@ async def test_vectorizer_api():
     try:
         print("开始测试A8矢量化服务...")
         result_url = await ai_client.vectorize_image(test_bytes.read())
-        print(f"测试成功! 矢量化后的EPS文件URL: {result_url}")
+        print(f"测试成功! 矢量化后的文件URL: {result_url}")
         return True
     except Exception as e:
         print(f"测试失败: {str(e)}")

--- a/backend/tests/integration/test_vectorizer.py
+++ b/backend/tests/integration/test_vectorizer.py
@@ -11,11 +11,11 @@ from app.services.ai_client import ai_client
 from app.core.config import settings
 
 async def test_vectorizer_api():
-    """测试Vectorizer.ai API集成"""
-    
-    # 检查API密钥是否配置
-    if not settings.vectorizer_api_key or not settings.vectorizer_api_secret:
-        print("错误: VECTORIZER_API_KEY 或 VECTORIZER_API_SECRET 未配置")
+    """测试A8矢量化服务集成"""
+
+    # 检查服务地址是否配置
+    if not settings.a8_vectorizer_base_url:
+        print("错误: A8_VECTORIZER_BASE_URL 未配置")
         return False
     
     # 创建一个测试图片
@@ -25,9 +25,9 @@ async def test_vectorizer_api():
     test_bytes.seek(0)
     
     try:
-        print("开始测试Vectorizer.ai API...")
+        print("开始测试A8矢量化服务...")
         result_url = await ai_client.vectorize_image(test_bytes.read())
-        print(f"测试成功! 矢量化后的SVG文件URL: {result_url}")
+        print(f"测试成功! 矢量化后的EPS文件URL: {result_url}")
         return True
     except Exception as e:
         print(f"测试失败: {str(e)}")
@@ -35,12 +35,11 @@ async def test_vectorizer_api():
 
 if __name__ == "__main__":
     # 设置测试环境变量
-    os.environ.setdefault("VECTORIZER_API_KEY", "YOUR_API_KEY_HERE")
-    os.environ.setdefault("VECTORIZER_API_SECRET", "YOUR_API_SECRET_HERE")
-    
+    os.environ.setdefault("A8_VECTORIZER_BASE_URL", "https://a8.zifeiyuai.top:2345")
+
     # 运行测试
     success = asyncio.run(test_vectorizer_api())
     if success:
-        print("Vectorizer.ai API集成测试通过!")
+        print("A8矢量化服务集成测试通过!")
     else:
-        print("Vectorizer.ai API集成测试失败!")
+        print("A8矢量化服务集成测试失败!")


### PR DESCRIPTION
## Summary
- add an async client wrapper for the A8 vectorizer API
- switch the vectorizer service to request EPS output via the new client
- expose configuration updates and refresh the integration test/.env example

## Testing
- python -m compileall backend/app/services/ai_client

------
https://chatgpt.com/codex/tasks/task_e_6900a822fe708333b6769fb74f176d83